### PR TITLE
Add scoreboard win percentages styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,21 @@ To run the app perform the following steps;
 
 ### Gameplay
 
-Left click on a square to reveal it. Revealing the first square starts the timer (unless it's a bomb!)
+Left click on a square to reveal it. Revealing the first square starts the timer - unless it's a bomb!
 
 If you reveal a square with a bomb, you lose. If you're logged in, your loss will be stored in the database and will decrease your win percentage for that difficulty.
 
 If the revealed square is safe it will show the number of (horizontally, vertically and diagonally) adjecent squares with bombs.
 
-If no surrounding squares have bombs, the revealed square will appear blank and the surrounding safe squares will automatically be revealed (triggering a cascade of square reveals)
+If no surrounding squares have bombs, the revealed square will appear blank and the surrounding safe squares will automatically be revealed (triggering a cascade of square reveals).
 
-You can right click an unrevealed square to mark it with a flag if you suspect it has a bomb. Right clicking a flagged square removes the flag
+You can right click an unrevealed square to mark it with a flag if you suspect it has a bomb. Right clicking a flagged square removes the flag.
 
-The flag counter below the board intially specifies the number of bombs on the board and decreases as you add flags to the board. You can place as many flags as you like. A negative counter just means you've placed more flags than there are bombs
+The flag counter below the board intially specifies the number of bombs on the board and decreases as you add flags to the board. You can place as many flags as you like. A negative counter just means you've placed more flags than there are bombs.
 
-Once all the safe squares have been revealed, you win the game. The timer will stop and, if you're logged in, your time will be automatically saved to the database. You can view your quickest winning times and win percentages (for each difficulty) on your user profile.
+Once all the safe squares have been revealed, you win the game. The timer will stop and (if you're logged in) your time will be automatically saved to the database. You can view your quickest winning times and win percentages (for each difficulty) on your user profile.
 
-Logged in users will also see a (functional) "Submit Time" button appear. Click this button to make your time publicly displayable. It will then appear on a public scoreboard (if it is one of the top ten times for that difficulty).
+If you're logged in, you will also see a (functional) "Submit Time" button appear. Click this button to make your time publicly displayable. It will then appear on a public scoreboard (if it is one of the top ten times for that difficulty).
 
 Please note that currently the "Submit Time" button appears to all users after a game is won, but will not do anything if clicked by a non-logged in user. The non-functional "Submit Time" button will be removed for non-logged users in an upcoming update (see upcoming improvements).
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,6 +23,10 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+h3 {
+  padding: 12px 0;
+}
+
 p.back-link {
   width: 180px;
 }

--- a/app/assets/stylesheets/profile.css
+++ b/app/assets/stylesheets/profile.css
@@ -2,7 +2,7 @@ body > main > section.details > div > p {
   white-space: nowrap;
 }
 
-body > main > section > div > p > span {
+body > main > section p > span {
   font-weight: 600;
 }
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,8 +18,6 @@ class UsersController < ApplicationController
 
   def show
     @user = user
-    @quickest_winning_play_time = quickest_winning_play&.time_in_seconds
-    @quickest_winning_play_difficulty = quickest_winning_play&.difficulty&.capitalize
     easy_plays = filter_plays_by_difficulty(user.plays, "easy")
     medium_plays = filter_plays_by_difficulty(user.plays, "medium")
     hard_plays = filter_plays_by_difficulty(user.plays, "hard")
@@ -61,10 +59,6 @@ class UsersController < ApplicationController
 
   def user
     User.find(@current_user.id)
-  end
-
-  def quickest_winning_play
-    get_all_winning_plays(user.plays).sort_by(&:time_in_seconds).first
   end
 
   def get_all_winning_plays(plays)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,8 +12,8 @@ module ApplicationHelper
   end
 
   def get_and_order_winning_plays(plays)
-    order_and_select_plays(plays.filter{ |play| play.is_win })
-  end  
+    order_and_select_plays(plays.filter(&:is_win))
+  end
 
   def get_and_order_displayable_plays(plays)
     order_and_select_plays(plays.filter{ |play| play.is_win && play.is_publicly_displayed })

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,21 +2,26 @@
 
 <section class="w-75 text-center">
   <div class="d-flex flex-column mb-5 text-wrap">
+  
     <p>Bombsweeper works just like Minesweeper only with bombs instead of mines and the option to save and track scores :)</p>
 
-    <p>Left click on a square to reveal it. Revealing the first square starts the timer (unless it's a bomb!)</p> 
-    
-    <p>If you reveal a square with a bomb, you lose. If the revealed square is safe it will show the number of (horizontally, vertically and diagonally) adjecent squares with bombs</p> 
-    
-    <p>If no surrounding squares have bombs, the revealed square will appear blank and the surrounding safe squares will automatically be revealed (triggering a cascade of square reveals)</p>
+    <p>Left click on a square to reveal it. Revealing the first square starts the timer - unless it's a bomb!</p>
 
-    <p>You can right click an unrevealed square to mark it with a flag if you suspect it has a bomb. Right clicking a flagged square removes the flag
+    <p>If you reveal a square with a bomb, you lose. If you're logged in, your loss will be stored in the database and will decrease your win percentage for that difficulty.</p>
+
+    <p>If the revealed square is safe it will show the number of (horizontally, vertically and diagonally) adjecent squares with bombs.</p> 
     
-    <p>The flag counter below the board intially specifies the number of bombs on the board and decreases as you add flags to the board. You can place as many flags as you like. A negative counter just means you've placed more flags than there are bombs</p>
+    <p>If no surrounding squares have bombs, the revealed square will appear blank and the surrounding safe squares will automatically be revealed (triggering a cascade of square reveals).</p>
 
-    <p>Once all the safe squares have been revealed, you win the game. The timer will stop and a "Submit Time" button will appear. If you're logged in, you can click the button to save your time. It will then appear on your profile (and on the scoreboard if it's good enough)</p>
+    <p>You can right click an unrevealed square to mark it with a flag if you suspect it has a bomb. Right clicking a flagged square removes the flag.</p>
+    
+    <p>The flag counter below the board intially specifies the number of bombs on the board and decreases as you add flags to the board. You can place as many flags as you like. A negative counter just means you've placed more flags than there are bombs.</p>
 
-    <p>You can reset the board and the timer at any time by clicking the "Reset" button</p>
+    <p>Once all the safe squares have been revealed, you win the game. The timer will stop and (if you're logged in) your time will be automatically saved to the database. You can view your quickest winning times and win percentages (for each difficulty) on your user profile.</p>
+
+    <p>If you're logged in, you will also see a "Submit Time" button appear. Click this button to make your time publicly displayable. It will then appear on a public scoreboard (if it is one of the top ten times for that difficulty).</p>
+
+    <p>If you wish to play again, click the "Reset" button. You can also click this button during a game. Games that are reset don't count towards your win percentages.</p>
 
     <p>Enjoy the game!</p>
   </div>  

--- a/app/views/shared/_account_features_list.html.erb
+++ b/app/views/shared/_account_features_list.html.erb
@@ -1,5 +1,5 @@
 <ul>
   <li>Save your winning times, so you can view them later</li>
-  <li>Track your win percentage and quickest time</li>
+  <li>Track your win percentages and quickest times</li>
   <li>Have your winning times displayed on the scoreboard</li>
 </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,9 +8,6 @@
   </div>  
   <div class="d-flex flex-column mx-3">
     <p><span>Joined:</span> <%= convert_time_to_date(@user.created_at) %></p>
-    <% if @quickest_winning_play_time %>
-      <p><span>Quickest Time:</span> <%= @quickest_winning_play_time %>s (<%= @quickest_winning_play_difficulty %>)</p>
-    <% end %>
   </div>
 </section>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,5 @@
 <h2>Hi <%= @user.username %>!</h2>
 
-<h3 class="mb-4">Details</h3>
-
 <section class="details d-flex justify-content-center w-75 mb-5">
   <div class="d-flex flex-column mx-3">
     <p><span>Email:</span> <%= @user.email %></p> 


### PR DESCRIPTION
Feature Added

- Profile scoreboard win percentage styling

Feature Removed

- Quickest Times displayed on profiles

Changes Made

- Adds padding to h3 heading
- Updates displayed instructions to account for updates to the ways plays are stored
- Updates account features text to account for updates to the way win percentages and quickest times are displayed
- Simplifies the get_and_order_plays method
- Updates README.md to match displayed instructions and fix punctuation